### PR TITLE
Add Makefile with development target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.PHONY: dev down
+
+# Start the development environment using docker-compose
+# Runs containers in the foreground so logs are visible
+# Usage: make dev
+
+
+dev:
+	docker-compose up --build
+
+# Stop containers started by `make dev`
+
+
+down:
+	docker-compose down


### PR DESCRIPTION
## Summary
- add a Makefile with a `dev` target to run docker-compose
- include a `down` target to stop the containers

## Testing
- `php -l index.php`
- `make -n dev`


------
https://chatgpt.com/codex/tasks/task_e_687df51e5404832894a67ecec21a1c6f